### PR TITLE
Fix Sventagliata to target only one player at a distance from the first target

### DIFF
--- a/backend/bang/expansions/the_valley_of_shadows/cards.py
+++ b/backend/bang/expansions/the_valley_of_shadows/cards.py
@@ -178,7 +178,7 @@ class Sventagliata(
             player.available_cards = [
                 dict(p, **{"original_target": against})
                 for p in player.game.get_visible_players(t)
-                if p["name"] != player.name and p["name"] != t.name and p["dist"]
+                if p["name"] != player.name and p["name"] != t.name and p["dist"] == 1
             ]
             if len(player.available_cards) > 0:
                 player.pending_action = PendingAction.CHOOSE

--- a/backend/tests/valley_of_shadows_test.py
+++ b/backend/tests/valley_of_shadows_test.py
@@ -330,6 +330,12 @@ def test_sventagliata():
     assert p.pending_action == PendingAction.PLAY
     assert len(p.hand) == 1
 
+    # Ensure the secondary target is at a distance from the first target
+    assert any(
+        target["name"] == secondary_target and target["dist"] > 1
+        for target in g.get_visible_players(p1)
+    )
+
 
 def test_mira():
     g = started_game(['the_valley_of_shadows'])


### PR DESCRIPTION
Related to #513

Update the `Sventagliata` card to restrict the secondary target to be at a distance from the first target.

* **backend/bang/expansions/the_valley_of_shadows/cards.py**
  - Modify the `play_card` method in the `Sventagliata` class to enforce distance constraints for the secondary target.
  - Ensure the secondary target selection logic only includes players at a distance of 1 from the first target.

* **backend/tests/valley_of_shadows_test.py**
  - Update the `test_sventagliata` test to verify the secondary target is at a distance from the first target.
  - Add assertions to ensure the secondary target is correctly chosen based on the distance constraint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/albertoxamin/bang/issues/513?shareId=989f4ed9-48a3-4df6-b508-68d7f2b47bf5).